### PR TITLE
Removes superfluous WP_DEBUG addition

### DIFF
--- a/provision/pmc/constants.sh
+++ b/provision/pmc/constants.sh
@@ -13,5 +13,7 @@ while IFS='' read -r -d '' key &&
     else
       noroot wp config set "${key}" "${value}"
     fi
+    # Enable WP_DEBUG in wp-config.php, already included via VVV's init.
+    noroot wp config set WP_DEBUG true --raw
 done
 set -e

--- a/provision/pmc/constants.yml
+++ b/provision/pmc/constants.yml
@@ -1,4 +1,3 @@
-WP_DEBUG: "true"
 WP_DEBUG_DISPLAY: "false"
 WP_DEBUG_LOG: "true"
 SCRIPT_DEBUG: "false"


### PR DESCRIPTION
When a site provision two instances of WP_DEBUG are included. The one, set to false, that ships with the `wp-config.php` file and the one we add set to true, which ends up being invalidated by the first. This PR removes the one we set and instead enables the one that ships with WordPress.

- Removes WP_DEBUG from the `contstants.yml` file.
- Adds `wp config set` command to the `constants.sh` file.