### PR TITLE
Revert "Removes superfluous WP_DEBUG addition"

### DIFF
--- a/provision/pmc/constants.sh
+++ b/provision/pmc/constants.sh
@@ -13,7 +13,5 @@ while IFS='' read -r -d '' key &&
     else
       noroot wp config set "${key}" "${value}"
     fi
-    # Enable WP_DEBUG in wp-config.php, already included via VVV's init.
-    noroot wp config set WP_DEBUG true --raw
 done
 set -e

--- a/provision/pmc/constants.yml
+++ b/provision/pmc/constants.yml
@@ -1,3 +1,4 @@
+WP_DEBUG: "true"
 WP_DEBUG_DISPLAY: "false"
 WP_DEBUG_LOG: "true"
 SCRIPT_DEBUG: "false"


### PR DESCRIPTION
Reverts penske-media-corp/pmc-vvv-site-provisioners#8

That PR didn't fix the issue it claims to. Because the value in `constants.yml` was set to `true`, the first condition is triggered in `constants.sh`, which calls the same command that was added in this PR.